### PR TITLE
fix: typo in configuration key definition

### DIFF
--- a/WWCP_OCPPv1.6/DataStructures/Complex/ConfigurationKey.cs
+++ b/WWCP_OCPPv1.6/DataStructures/Complex/ConfigurationKey.cs
@@ -434,7 +434,7 @@ namespace cloud.charging.open.protocols.OCPPv1_6
         /// it reads out all configuration keys.
         /// This configuration key is required unless only "security profile 3 - TLS with client side certificates" is implemented.
         /// </summary>
-        public static readonly ConfigurationKey AuthorizationKey                = new (Keys.WebSocketPingInterval,
+        public static readonly ConfigurationKey AuthorizationKey                = new (Keys.AuthorizationKey,
                                                                                        KeyStatus.   Optional,
                                                                                        AccessRights.WriteOnly,
                                                                                        ValueTypes.  String,


### PR DESCRIPTION
Looks like a typo in the region where the well-known configuration keys are defined, probably a copy+paste error.

AuthorizationKey is incorrectly named WebSocketPingInterval.

This PR fixes the issue, giving the key its correct name.